### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,5 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+gem 'payjp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -99,6 +101,9 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -123,6 +128,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -138,6 +146,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -148,6 +157,8 @@ GEM
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.4.5)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -197,6 +208,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
@@ -267,6 +283,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.3.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -307,6 +326,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)
+  payjp
   pg
   pry-rails
   puma (~> 3.11)

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the orders controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/orders/index.css
+++ b/app/assets/stylesheets/orders/index.css
@@ -1,0 +1,157 @@
+.transaction-contents {
+  width: 100vw;
+  background-color: #f5f5f5;
+  display: flex;
+  justify-content: center;
+}
+
+.transaction-main {
+  background-color: #FFF;
+  width: 70vw;
+  min-width: 450px;
+  padding: 10vh 10vw;
+}
+
+.transaction-title-text {
+  text-align: center;
+  border-bottom: 2px solid #f5f5f5;
+  font-weight: bold;
+  font-size: 22px;
+}
+
+/* 購入内容の表示 */
+.buy-item-info {
+  height: 150px;
+  border-bottom: 2px solid #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.buy-item-img {
+  margin-right: 20px;
+  height: 130px;
+  width: 250px;
+  object-fit: contain;
+}
+
+.buy-item-right-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.buy-item-text {
+  font-size: 20px;
+}
+
+.buy-item-price {
+  display: flex;
+  font-weight: bold;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.item-price-text {
+  font-size: 15px;
+  margin-right: 20px;
+}
+
+.item-price-sub-text {
+  font-size: 12px;
+}
+
+/* /購入内容の表示 */
+
+/* 支払額の表示 */
+.item-payment {
+  height: 120px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  border-bottom: 2px solid #f5f5f5;
+  font-weight: bold;
+}
+
+.item-payment-title {
+  font-size: 20px;
+}
+
+.item-payment-price {
+  font-size: 25px;
+}
+
+/* /支払額の表示 */
+
+/* カード情報の入力 */
+.credit-card-form {
+  border-bottom: 2px solid #f5f5f5;
+  margin-top: 15px;
+  padding-bottom: 30px;
+}
+
+.info-input-haedline {
+  text-align: center;
+  font-weight: bold;
+  font-size: 20px;
+}
+
+.available-card {
+  display: flex;
+  height: 35px;
+}
+
+.card-logo {
+  width: 40px;
+  margin: 5px 5px;
+}
+
+.input-expiration-date-wrap {
+  width: 100%;
+  display: flex;
+  text-align: center;
+  line-height: 55px;
+}
+
+.input-expiration-date {
+  width: 20%;
+  margin-top: 5px;
+  height: 48px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+  font-size: 16px;
+  resize: none;
+  line-height: 45px;
+  text-align: center;
+}
+
+/* /カード情報の入力 */
+
+/* 配送先の入力 */
+.shipping-address-form {
+  margin-top: 15px;
+}
+
+.form-any {
+  background: #ccc;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px;
+}
+
+.buy-btn {
+  width: 50%;
+  margin: 0 auto;
+  margin-top: 50px;
+}
+
+.buy-red-btn {
+  width: 100%;
+  background: #ea352d;
+  border: 1px solid #ea352d;
+  color: #fff;
+  line-height: 48px;
+  font-size: 14px;
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/orders/index.css
+++ b/app/assets/stylesheets/orders/index.css
@@ -113,9 +113,9 @@
 }
 
 .input-expiration-date {
-  width: 20%;
+  width: 30%;
   margin-top: 5px;
-  height: 48px;
+  height: 24px;
   border-radius: 4px;
   border: 1px solid #ccc;
   background: #fff;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,9 +24,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    if  @item.order.present?
-      redirect_to root_path
-    end
+    return unless @item.order.present?
+
+    redirect_to root_path
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    if  @item.order.present?
+      redirect_to root_path
+    end
   end
 
   def update

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,2 @@
+class OrdersController < ApplicationController
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,10 +5,10 @@ class OrdersController < ApplicationController
     @order_payment = OrderPayment.new
     @item = Item.find(params[:item_id])
     if current_user == @item.user
-     redirect_to root_path
+      redirect_to root_path
     elsif current_user != @item.user && @item.order.present?
-      redirect_to root_path 
-    end 
+      redirect_to root_path
+    end
   end
 
   def create
@@ -23,23 +23,22 @@ class OrdersController < ApplicationController
     else
       render :index
     end
-
   end
 
   private
 
   def order_params
-    params.require(:order_payment).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+    params.require(:order_payment).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(
+      user_id: current_user.id, item_id: params[:item_id], token: params[:token]
+    )
   end
 
   def pay_item
     Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     Payjp::Charge.create(
       amount: @item.price,
-      card: order_params[:token],    
-      currency: 'jpy'                 
+      card: order_params[:token],
+      currency: 'jpy'
     )
   end
-
-
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -6,7 +6,9 @@ class OrdersController < ApplicationController
     @item = Item.find(params[:item_id])
     if current_user == @item.user
      redirect_to root_path
-    end
+    elsif current_user != @item.user && @item.order.present?
+      redirect_to root_path 
+    end 
   end
 
   def create
@@ -38,5 +40,6 @@ class OrdersController < ApplicationController
       currency: 'jpy'                 
     )
   end
+
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,6 +2,7 @@ class OrdersController < ApplicationController
 
   def index
     @order_payment = OrderPayment.new
+    @item = Item.find(params[:item_id])
   end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,2 +1,7 @@
 class OrdersController < ApplicationController
+
+  def index
+    @order_payment = OrderPayment.new
+  end
+
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -13,6 +13,9 @@ class OrdersController < ApplicationController
     @order_payment = OrderPayment.new(order_params)
     @item = Item.find(params[:item_id])
     if @order_payment.valid?
+
+      pay_item
+
       @order_payment.save
       redirect_to root_path
     else
@@ -24,7 +27,16 @@ class OrdersController < ApplicationController
   private
 
   def order_params
-    params.require(:order_payment).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
+    params.require(:order_payment).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def pay_item
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp::Charge.create(
+      amount: @item.price,
+      card: order_params[:token],    
+      currency: 'jpy'                 
+    )
   end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,9 +1,9 @@
 class OrdersController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_item, only: [:index, :create]
 
   def index
     @order_payment = OrderPayment.new
-    @item = Item.find(params[:item_id])
     if current_user == @item.user
       redirect_to root_path
     elsif current_user != @item.user && @item.order.present?
@@ -13,7 +13,6 @@ class OrdersController < ApplicationController
 
   def create
     @order_payment = OrderPayment.new(order_params)
-    @item = Item.find(params[:item_id])
     if @order_payment.valid?
 
       pay_item
@@ -41,4 +40,9 @@ class OrdersController < ApplicationController
       currency: 'jpy'
     )
   end
+
+  def set_item
+    @item = Item.find(params[:item_id])
+  end
+
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,4 +1,5 @@
 class OrdersController < ApplicationController
+  before_action :authenticate_user!
 
   def index
     @order_payment = OrderPayment.new

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,6 +4,9 @@ class OrdersController < ApplicationController
   def index
     @order_payment = OrderPayment.new
     @item = Item.find(params[:item_id])
+    if current_user == @item.user
+     redirect_to root_path
+    end
   end
 
   def create

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,4 +5,22 @@ class OrdersController < ApplicationController
     @item = Item.find(params[:item_id])
   end
 
+  def create
+    @order_payment = OrderPayment.new(order_params)
+    @item = Item.find(params[:item_id])
+    if @order_payment.valid?
+      @order_payment.save
+      redirect_to root_path
+    else
+      render :index
+    end
+
+  end
+
+  private
+
+  def order_params
+    params.require(:order_payment).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
+  end
+
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+  //環境変数をもとに公開鍵を呼び出す
+  const payjp = Payjp(process.env.PAYJP_PUBLIC_KEY); 
+  //elementsインスタンスを生成
+  const elements = payjp.elements();
+  //入力欄ごとにelementインスタンスを生成
+  const numberElement = elements.create('cardNumber')
+  const cvcElement = elements.create('cardCvc')
+  const expiryElement = elements.create('cardExpiry')
+  //入力欄をブラウザ上に表示
+  numberElement.mount('#number')
+  cvcElement.mount('#cvc') 
+  expiryElement.mount('#exp-date')
+  //フォームの要素を取得
+  const form = document.getElementById("charge-form");
+  //PAY.JPと通信が成功した場合のみトークンをフォームに埋め込む
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    payjp.createToken(expiryElement).then((response) => {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form"); 
+        const tokenObj = `<input value=${token} name='token' type="hidden"> `;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      document.getElementById("charge-form").submit();
+    });
+  });
+};
+
+window.addEventListener("load", pay);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../item_price");
+require("../card");
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,14 +12,16 @@ class Item < ApplicationRecord
 
   has_one_attached :image
 
-  validates :name,             presence: true
-  validates :description,      presence: true
-  validates :category_id,      presence: true, numericality: { other_than: 0, message: "can't be blank" }
-  validates :status_id,        presence: true, numericality: { other_than: 0, message: "can't be blank" }
-  validates :shipping_cost_id, presence: true, numericality: { other_than: 0, message: "can't be blank" }
-  validates :prefecture_id,    presence: true, numericality: { other_than: 0, message: "can't be blank" }
-  validates :shipping_day_id,  presence: true, numericality: { other_than: 0, message: "can't be blank" }
-  validates :price,            presence: true,
-                               numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'out of range' }
-  validates :image,            presence: true
+  with_options presence: true do
+   validates :name
+   validates :description
+   validates :category_id,      numericality: { other_than: 0, message: "can't be blank" }
+   validates :status_id,        numericality: { other_than: 0, message: "can't be blank" }
+   validates :shipping_cost_id, numericality: { other_than: 0, message: "can't be blank" }
+   validates :prefecture_id,    numericality: { other_than: 0, message: "can't be blank" }
+   validates :shipping_day_id,  numericality: { other_than: 0, message: "can't be blank" }
+   validates :price,            numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'out of range' }
+   validates :image
+  end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   belongs_to :shipping_day
 
   belongs_to :user
-  # has_one    :order
+  has_one    :order
 
   has_one_attached :image
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,2 @@
+class Order < ApplicationRecord
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,5 @@
 class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :payment
 end

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -1,7 +1,7 @@
 class OrderPayment
   include ActiveModel::Model
 
-  attr_accessor :order_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number
+  attr_accessor :user_id, :item_id, :order_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number
 
   with_options presence: true do
     validates :postcode, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)" }
@@ -12,6 +12,7 @@ class OrderPayment
   end
 
   def save    
+    order = Order.create(user_id: user_id, item_id:item_id)
     Payment.create(postcode: postcode, prefecture_id: prefecture_id, city: city, block: block, building: building, phone_number: phone_number, order_id: order.id )
   end
 

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -1,0 +1,6 @@
+class OrderPayment
+  include ActiveModel::Model
+
+
+
+end

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -1,7 +1,7 @@
 class OrderPayment
   include ActiveModel::Model
 
-  attr_accessor :user_id, :item_id, :order_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number, :token
+  attr_accessor :user_id, :item_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number, :token
 
   with_options presence: true do
     validates :user_id

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -6,17 +6,17 @@ class OrderPayment
   with_options presence: true do
     validates :user_id
     validates :item_id
-    validates :postcode, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)" }
+    validates :postcode, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
     validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
     validates :city
     validates :block
-    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: "not correct" }
+    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'not correct' }
     validates :token
   end
 
-  def save    
-    order = Order.create(user_id: user_id, item_id:item_id)
-    Payment.create(postcode: postcode, prefecture_id: prefecture_id, city: city, block: block, building: building, phone_number: phone_number, order_id: order.id )
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Payment.create(postcode: postcode, prefecture_id: prefecture_id, city: city, block: block, building: building,
+                   phone_number: phone_number, order_id: order.id)
   end
-
 end

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -1,6 +1,18 @@
 class OrderPayment
   include ActiveModel::Model
 
+  attr_accessor :order_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number
 
+  with_options presence: true do
+    validates :postcode, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)" }
+    validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :city
+    validates :block
+    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: "not correct" }
+  end
+
+  def save    
+    Payment.create(postcode: postcode, prefecture_id: prefecture_id, city: city, block: block, building: building, phone_number: phone_number, order_id: order.id )
+  end
 
 end

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -4,6 +4,8 @@ class OrderPayment
   attr_accessor :user_id, :item_id, :order_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number
 
   with_options presence: true do
+    validates :user_id
+    validates :item_id
     validates :postcode, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)" }
     validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
     validates :city

--- a/app/models/order_payment.rb
+++ b/app/models/order_payment.rb
@@ -1,7 +1,7 @@
 class OrderPayment
   include ActiveModel::Model
 
-  attr_accessor :user_id, :item_id, :order_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number
+  attr_accessor :user_id, :item_id, :order_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number, :token
 
   with_options presence: true do
     validates :user_id
@@ -11,6 +11,7 @@ class OrderPayment
     validates :city
     validates :block
     validates :phone_number, format: { with: /\A\d{10,11}\z/, message: "not correct" }
+    validates :token
   end
 
   def save    

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,2 @@
+class Payment < ApplicationRecord
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,2 +1,3 @@
 class Payment < ApplicationRecord
+  belongs_to :order
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :orders
 
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
   validates :password, format: { with: VALID_PASSWORD_REGEX, message: 'Include both letters and numbers' }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,10 +10,13 @@ class User < ApplicationRecord
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
   validates :password, format: { with: VALID_PASSWORD_REGEX, message: 'Include both letters and numbers' }
 
-  validates :nickname,         presence: true
-  validates :first_name,       presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
-  validates :family_name,      presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
-  validates :first_name_kana,  presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
-  validates :family_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
-  validates :birth_day,        presence: true
+  with_options presence: true do
+   validates :nickname
+   validates :first_name,       format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
+   validates :family_name,      format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
+   validates :first_name_kana,  format: { with: /\A[ァ-ヶー－]+\z/ }
+   validates :family_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
+   validates :birth_day
+  end
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,11 +134,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <% if item.order.present? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <% end %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.order.present? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,16 +23,19 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", edit_item_path(@item.id) , method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", item_path(@item.id) , method: :delete, class:"item-destroy" %>
-    <% end %>
+    <%#ユーザーがログインしている%>
+      <% if user_signed_in? %>
+      
+      <%#自身が出品した販売中商品の場合%>
+      <% if current_user.id == @item.user_id && @item.order.nil? %>
+      <%= link_to "商品の編集", edit_item_path(@item.id) , method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", item_path(@item.id) , method: :delete, class:"item-destroy" %>
+      <%#自身が出品していない販売中商品の場合%>
+      <%# elsif current_user.id != @item.user_id && @item.order.nil?%>
+      <%#= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
+      <% end %>
 
-    <% if user_signed_in? && current_user.id != @item.user_id %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <%#ユーザーがログインしている%>
-      <% if user_signed_in? %>
+    <% if user_signed_in? %>
       
       <%#自身が出品した販売中商品の場合%>
       <% if current_user.id == @item.user_id && @item.order.nil? %>
@@ -32,8 +32,8 @@
       <p class="or-text">or</p>
       <%= link_to "削除", item_path(@item.id) , method: :delete, class:"item-destroy" %>
       <%#自身が出品していない販売中商品の場合%>
-      <%# elsif current_user.id != @item.user_id && @item.order.nil?%>
-      <%#= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
+      <% elsif current_user.id != @item.user_id && @item.order.nil? %>
+      <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
       <% end %>
 
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
 
     <% if user_signed_in? && current_user.id != @item.user_id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <title>Furima</title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <script type="text/javascript" src="https://js.pay.jp/v1/"></script>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
   <%= stylesheet_link_tag 'application', media: 'all'%>
   <%= javascript_pack_tag 'application' %>
 </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,130 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= "商品名" %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= '999,999,999' %></p>
+          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= "販売価格" %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%# カード情報の入力 %>
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div class='input-expiration-date-wrap'>
+          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
+          <p>月</p>
+          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
+          <p>年</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
+      </div>
+    </div>
+    <%# /カード情報の入力 %>
+    
+    <%# 配送先の入力 %>
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+    <%# /配送先の入力 %>
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_cost.name %></p>
         </div>
       </div>
     </div>
@@ -26,7 +26,7 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -36,6 +36,7 @@
     <%= render 'shared/error_messages', model: f.object %>
    
     <%# カード情報の入力 %>
+      
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
         クレジットカード情報入力
@@ -45,7 +46,7 @@
           <label class="form-text">カード情報</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
+        <%= f.text_field :number, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
         <div class='available-card'>
           <%= image_tag 'card-visa.gif', class: 'card-logo'%>
           <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
@@ -59,9 +60,9 @@
           <span class="indispensable">必須</span>
         </div>
         <div class='input-expiration-date-wrap'>
-          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
+          <%= f.text_area :exp_month, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
           <p>月</p>
-          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
+          <%= f.text_area :exp_year, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
           <p>年</p>
         </div>
       </div>
@@ -70,7 +71,7 @@
           <label class="form-text">セキュリティコード</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
+        <%= f.text_field :cvc, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
       </div>
     </div>
     <%# /カード情報の入力 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -31,7 +31,10 @@
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_payment, url: item_orders_path(@item), id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+   
+    <%= render 'shared/error_messages', model: f.object %>
+   
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -82,42 +85,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :postcode, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name,  {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :block, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -66,7 +66,7 @@
         </div>
         <div class='input-expiration-date-wrap'>
 
-           <div id='exp-date' class="input-expiration-date">
+           <div id='exp-date' class="input-default">
            </div>
 
         </div>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -46,7 +46,10 @@
           <label class="form-text">カード情報</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :number, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
+
+        <div id='number' class="input-default" >
+           </div>
+        
         <div class='available-card'>
           <%= image_tag 'card-visa.gif', class: 'card-logo'%>
           <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
@@ -54,26 +57,35 @@
           <%= image_tag 'card-amex.gif', class: 'card-logo'%>
         </div>
       </div>
+
+
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">有効期限</label>
           <span class="indispensable">必須</span>
         </div>
         <div class='input-expiration-date-wrap'>
-          <%= f.text_area :exp_month, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
-          <p>月</p>
-          <%= f.text_area :exp_year, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
-          <p>年</p>
+
+           <div id='exp-date' class="input-expiration-date">
+           </div>
+
         </div>
       </div>
+
+
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">セキュリティコード</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :cvc, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
+        
+          <div id='cvc' class="input-default" >
+           </div>
+
       </div>
+
     </div>
+    
     <%# /カード情報の入力 %>
     
     <%# 配送先の入力 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items
+  resources :items do
+    resources :orders, only: [:index, :create]
+   end
 end

--- a/db/migrate/20230115071541_create_orders.rb
+++ b/db/migrate/20230115071541_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230115071819_create_payments.rb
+++ b/db/migrate/20230115071819_create_payments.rb
@@ -1,0 +1,14 @@
+class CreatePayments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :payments do |t|
+      t.references :order,         null: false, foreign_key: true
+      t.string     :postcode,      null: false
+      t.integer    :prefecture_id, null: false
+      t.string     :city,          null: false
+      t.string     :block,         null: false
+      t.string     :building
+      t.string     :phone_number,  null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_06_050124) do
+ActiveRecord::Schema.define(version: 2023_01_15_071819) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,28 @@ ActiveRecord::Schema.define(version: 2023_01_06_050124) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
+  create_table "payments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.string "postcode", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "block", null: false
+    t.string "building"
+    t.string "phone_number", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_payments_on_order_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -68,4 +90,7 @@ ActiveRecord::Schema.define(version: 2023_01_06_050124) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
+  add_foreign_key "payments", "orders"
 end

--- a/spec/factories/order_payments.rb
+++ b/spec/factories/order_payments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order_payment do
+    
+  end
+end

--- a/spec/factories/order_payments.rb
+++ b/spec/factories/order_payments.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
-  factory :order_payment do
+      factory :order_payment do
+        postcode      { 111-1111 }
+        prefecture_id { 1 }
+        city          { "大阪市" }
+        block         { "大阪6-5" }
+        building      { "大阪ビル" }
+        phone_number  { 11111111111 }
     
   end
 end

--- a/spec/factories/order_payments.rb
+++ b/spec/factories/order_payments.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
       factory :order_payment do
-        postcode      { 111-1111 }
+        postcode      { "111-1111" }
         prefecture_id { 1 }
         city          { "大阪市" }
         block         { "大阪6-5" }

--- a/spec/factories/order_payments.rb
+++ b/spec/factories/order_payments.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
-      factory :order_payment do
-        postcode      { "111-1111" }
-        prefecture_id { 1 }
-        city          { "大阪市" }
-        block         { "大阪6-5" }
-        building      { "大阪ビル" }
-        phone_number  { 11111111111 }
-        token         { "tok_8b97bf4c7f98ec77ed769ff79298" }
+  factory :order_payment do
+    postcode { '111-1111' }
+    prefecture_id { 1 }
+    city          { '大阪市' }
+    block         { '大阪6-5' }
+    building      { '大阪ビル' }
+    phone_number  { 11_111_111_111 }
+    token         { 'tok_8b97bf4c7f98ec77ed769ff79298' }
   end
 end

--- a/spec/factories/order_payments.rb
+++ b/spec/factories/order_payments.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
         block         { "大阪6-5" }
         building      { "大阪ビル" }
         phone_number  { 11111111111 }
-    
+        token         { "tok_8b97bf4c7f98ec77ed769ff79298" }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :order do
-    
   end
 end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :payment do
+    
+  end
+end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :payment do
-    
   end
 end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_payment_spec.rb
+++ b/spec/models/order_payment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OrderPayment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_payment_spec.rb
+++ b/spec/models/order_payment_spec.rb
@@ -1,31 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe OrderPayment, type: :model do
-
   before do
     @user = FactoryBot.create(:user)
     @item = FactoryBot.create(:item)
-    @order_payment = FactoryBot.build(:order_payment,user_id: @user.id, item_id: @item.id)
+    @order_payment = FactoryBot.build(:order_payment, user_id: @user.id, item_id: @item.id)
     sleep(0.1)
   end
 
   describe '商品の購入' do
-
     context '購入できる時' do
+      it 'すべての項目が正しく入力されていれば購入できる' do
+        expect(@order_payment).to be_valid
+      end
 
-     it 'すべての項目が正しく入力されていれば購入できる' do
-      expect(@order_payment).to be_valid
-     end
-
-     it '建物名が空でも購入できる' do
-      @order_payment.building = ''
-      expect(@order_payment).to be_valid
-     end
-
+      it '建物名が空でも購入できる' do
+        @order_payment.building = ''
+        expect(@order_payment).to be_valid
+      end
     end
 
     context '購入できない時' do
-
       it 'user_idがなければ購入できない' do
         @order_payment.user_id = ' '
         @order_payment.valid?
@@ -47,7 +42,7 @@ RSpec.describe OrderPayment, type: :model do
       it '郵便番号が「3桁ハイフン4桁」の半角文字列でないと購入できない' do
         @order_payment.postcode = '1111111'
         @order_payment.valid?
-        expect(@order_payment.errors.full_messages).to include("Postcode is invalid. Include hyphen(-)")
+        expect(@order_payment.errors.full_messages).to include('Postcode is invalid. Include hyphen(-)')
       end
 
       it '都道府県の情報が空だと購入できない' do
@@ -81,25 +76,22 @@ RSpec.describe OrderPayment, type: :model do
       end
 
       it '電話番号は10桁未満では購入できない' do
-        @order_payment.phone_number = 111111111
+        @order_payment.phone_number = 111_111_111
         @order_payment.valid?
-        expect(@order_payment.errors.full_messages).to include("Phone number not correct")
+        expect(@order_payment.errors.full_messages).to include('Phone number not correct')
       end
 
       it '電話番号は12桁以上では購入できない' do
-        @order_payment.phone_number = 111111111111
+        @order_payment.phone_number = 111_111_111_111
         @order_payment.valid?
-        expect(@order_payment.errors.full_messages).to include("Phone number not correct")
+        expect(@order_payment.errors.full_messages).to include('Phone number not correct')
       end
 
       it 'トークンが空だと購入できない' do
-        @order_payment.token = " "
+        @order_payment.token = ' '
         @order_payment.valid?
         expect(@order_payment.errors.full_messages).to include("Token can't be blank")
       end
-
-    end  
-  
+    end
   end
-
 end

--- a/spec/models/order_payment_spec.rb
+++ b/spec/models/order_payment_spec.rb
@@ -87,6 +87,12 @@ RSpec.describe OrderPayment, type: :model do
         expect(@order_payment.errors.full_messages).to include('Phone number not correct')
       end
 
+      it '電話番号に半角数字以外が含まれている場合は購入できない' do
+        @order_payment.phone_number = '111-1111-1111'
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include('Phone number not correct')
+      end
+
       it 'トークンが空だと購入できない' do
         @order_payment.token = ' '
         @order_payment.valid?

--- a/spec/models/order_payment_spec.rb
+++ b/spec/models/order_payment_spec.rb
@@ -1,5 +1,99 @@
 require 'rails_helper'
 
 RSpec.describe OrderPayment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  before do
+    @user = FactoryBot.create(:user)
+    @item = FactoryBot.create(:item)
+    @order_payment = FactoryBot.build(:order_payment,user_id: @user.id, item_id: @item.id)
+    sleep(0.1)
+  end
+
+  describe '商品の購入' do
+
+    context '購入できる時' do
+
+     it 'すべての項目が正しく入力されていれば購入できる' do
+      expect(@order_payment).to be_valid
+     end
+
+     it '建物名が空でも購入できる' do
+      @order_payment.building = ''
+      expect(@order_payment).to be_valid
+     end
+
+    end
+
+    context '購入できない時' do
+
+      it 'user_idがなければ購入できない' do
+        @order_payment.user_id = ' '
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("User can't be blank")
+      end
+
+      it 'item_idがなければ購入できない' do
+        @order_payment.item_id = ' '
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Item can't be blank")
+      end
+
+      it '郵便番号が空では購入できない' do
+        @order_payment.postcode = ''
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Postcode can't be blank")
+      end
+
+      it '郵便番号が「3桁ハイフン4桁」の半角文字列でないと購入できない' do
+        @order_payment.postcode = '1111111'
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Postcode is invalid. Include hyphen(-)")
+      end
+
+      it '都道府県の情報が空だと購入できない' do
+        @order_payment.prefecture_id = ' '
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Prefecture can't be blank")
+      end
+
+      it '都道府県に「---」が選択されている場合は購入できない' do
+        @order_payment.prefecture_id = 0
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Prefecture can't be blank")
+      end
+
+      it '市区町村が空だと購入できない' do
+        @order_payment.city = ' '
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("City can't be blank")
+      end
+
+      it '番地が空だと購入できない' do
+        @order_payment.block = ' '
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Block can't be blank")
+      end
+
+      it '電話番号が空だと購入できない' do
+        @order_payment.phone_number = ' '
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Phone number can't be blank")
+      end
+
+      it '電話番号は10桁未満では購入できない' do
+        @order_payment.phone_number = 111111111
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Phone number not correct")
+      end
+
+      it '電話番号は12桁以上では購入できない' do
+        @order_payment.phone_number = 111111111111
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Phone number not correct")
+      end
+
+    end  
+  
+  end
+
 end

--- a/spec/models/order_payment_spec.rb
+++ b/spec/models/order_payment_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe OrderPayment, type: :model do
         expect(@order_payment.errors.full_messages).to include("Phone number not correct")
       end
 
+      it 'トークンが空だと購入できない' do
+        @order_payment.token = " "
+        @order_payment.valid?
+        expect(@order_payment.errors.full_messages).to include("Token can't be blank")
+      end
+
     end  
   
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Payment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Orders", type: :request do
-
+RSpec.describe 'Orders', type: :request do
 end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
# What
・商品購入機能を実装
・これ以前の実装で残していた購入後の分岐（soldoutの表示など）の完了
・モデルの単体テストコードを書いた

# Why
・ユーザーが商品を購入できるようにするため

# Gyazo
・必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/e04f095662ecd865269b3032935f9afd
・入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/a9d8412aa6024780d267c11a49eca24b
・ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/5fd2bc7c9bdbf6f4199ea723d4ac5700
・ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/40a735eaadd6e52bfda5d5a9fc9026e0
・ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/88dafef8d273e68bcd4d87df68c3de6f

・売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
・売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
・ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/9052fbd7361613ab53f1862a3f4dd7fc
https://gyazo.com/e385448a9a1365dbb646bc0b9fa7d92a

 ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/642cead365577f409babf864a17fa8df
 テスト結果の画像
https://gyazo.com/3ec7203a7d518bbd79d0fb40a23091d4